### PR TITLE
Implement prototype chatbot modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+beautifulsoup4
+scikit-learn
+vaderSentiment
+pytest

--- a/subscription_bot/__init__.py
+++ b/subscription_bot/__init__.py
@@ -1,0 +1,1 @@
+"""SubscriptionHub Chatbot package."""

--- a/subscription_bot/chatbot.py
+++ b/subscription_bot/chatbot.py
@@ -1,0 +1,13 @@
+"""High-level chatbot interface combining intent classification and responses."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .intent_classifier import predict_intent
+from .response import generate_response
+
+
+def answer(question: str, context: Optional[dict] = None) -> str:
+    """Return chatbot answer for ``question`` using optional ``context``."""
+    intent = predict_intent(question)
+    return generate_response(intent, question, context)

--- a/subscription_bot/crawler.py
+++ b/subscription_bot/crawler.py
@@ -1,0 +1,44 @@
+"""Simple web crawler to fetch review content.
+
+This module provides a basic example of fetching a web page and
+extracting title and paragraph text using BeautifulSoup.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def crawl_review(url: str, source: str = "unknown") -> Dict[str, str]:
+    """Fetch ``url`` and extract a review-like JSON structure.
+
+    Parameters
+    ----------
+    url:
+        URL to crawl.
+    source:
+        Optional label for the source of the review.
+
+    Returns
+    -------
+    dict
+        A dictionary with ``title``, ``content``, ``source`` and
+        ``published_at`` fields.
+    """
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    title = soup.title.string.strip() if soup.title else ""
+    content = " ".join(p.get_text(strip=True) for p in soup.find_all("p"))
+
+    return {
+        "title": title,
+        "content": content,
+        "source": source,
+        "published_at": datetime.utcnow().strftime("%Y-%m-%d"),
+    }

--- a/subscription_bot/intent_classifier.py
+++ b/subscription_bot/intent_classifier.py
@@ -1,0 +1,46 @@
+"""Intent classifier using TF-IDF and Logistic Regression.
+
+For demonstration, a small dataset is embedded directly in this module.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+
+# Sample training data based on PRD examples
+SAMPLE_DATA = [
+    ("내 구독 목록 알려줘", "조회"),
+    ("넷플릭스랑 디즈니플러스 뭐가 달라?", "비교"),
+    ("가성비 좋은 OTT 뭐 있어?", "추천"),
+    ("유튜브 프리미엄 해지하고 싶어요", "해지"),
+    ("계속 써야 할지 고민이에요", "고민"),
+]
+
+
+@dataclass
+class IntentClassifier:
+    """Simple wrapper around scikit-learn classifier."""
+
+    vectorizer: TfidfVectorizer
+    model: LogisticRegression
+
+    def train(self, texts: List[str], labels: List[str]) -> None:
+        X = self.vectorizer.fit_transform(texts)
+        self.model.fit(X, labels)
+
+    def predict(self, text: str) -> str:
+        X = self.vectorizer.transform([text])
+        return self.model.predict(X)[0]
+
+
+# Create and train the classifier on import for ease of use
+_classifier = IntentClassifier(TfidfVectorizer(), LogisticRegression())
+_classifier.train([q for q, _ in SAMPLE_DATA], [l for _, l in SAMPLE_DATA])
+
+
+def predict_intent(text: str) -> str:
+    """Predict intent for ``text`` using the pre-trained classifier."""
+    return _classifier.predict(text)

--- a/subscription_bot/response.py
+++ b/subscription_bot/response.py
@@ -1,0 +1,27 @@
+"""Rule-based response generator with simple fallback."""
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+RULES: Dict[str, Callable[[dict], str]] = {
+    "조회": lambda ctx: "현재 구독 중인 상품은 {}입니다.".format(
+        ", ".join(ctx.get("subscriptions", []) or ["없음"])
+    ),
+    "비교": lambda ctx: "비교 결과: 각 서비스마다 장단점이 있어요.",
+    "추천": lambda ctx: "사용자님께는 {}를 추천합니다.".format(
+        ctx.get("recommendation", "넷플릭스")
+    ),
+    "해지": lambda ctx: "구독 해지는 설정 > 구독관리에서 가능합니다.",
+    "고민": lambda ctx: "고민이 되신다면 무료 체험을 먼저 이용해보세요.",
+}
+
+
+def generate_response(intent: str, question: str, context: Optional[dict] = None) -> str:
+    """Generate response based on ``intent`` and optional ``context``.
+
+    If ``intent`` is not in predefined rules, a fallback message is returned.
+    """
+    context = context or {}
+    if intent in RULES:
+        return RULES[intent](context)
+    return "죄송해요. 아직 잘 모르겠어요."

--- a/subscription_bot/sentiment.py
+++ b/subscription_bot/sentiment.py
@@ -1,0 +1,17 @@
+"""Sentiment analysis using VADER."""
+from __future__ import annotations
+
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+_analyzer = SentimentIntensityAnalyzer()
+
+
+def analyze_sentiment(text: str) -> str:
+    """Return sentiment label (긍정/부정/중립) for ``text``."""
+    scores = _analyzer.polarity_scores(text)
+    compound = scores["compound"]
+    if compound >= 0.05:
+        return "긍정"
+    if compound <= -0.05:
+        return "부정"
+    return "중립"

--- a/subscription_bot/summarizer.py
+++ b/subscription_bot/summarizer.py
@@ -1,0 +1,14 @@
+"""Simple text summarizer placeholder."""
+from __future__ import annotations
+
+
+def summarize(text: str, max_sentences: int = 3) -> str:
+    """Return the first ``max_sentences`` from ``text``.
+
+    This is a placeholder for an actual summarization model.
+    """
+    sentences = [s.strip() for s in text.split(".") if s.strip()]
+    summary = ". ".join(sentences[:max_sentences])
+    if summary and not summary.endswith("."):
+        summary += "."
+    return summary

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_intent_classifier.py
+++ b/tests/test_intent_classifier.py
@@ -1,0 +1,6 @@
+from subscription_bot.intent_classifier import predict_intent
+
+
+def test_predict_intent():
+    assert predict_intent("내 구독 목록 알려줘") == "조회"
+    assert predict_intent("유튜브 프리미엄 해지하고 싶어요") == "해지"

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,12 @@
+from subscription_bot.response import generate_response
+
+
+def test_rule_response():
+    ctx = {"subscriptions": ["넷플릭스"]}
+    resp = generate_response("조회", "내 구독 알려줘", ctx)
+    assert "넷플릭스" in resp
+
+
+def test_fallback():
+    resp = generate_response("기타", "모르는 질문", {})
+    assert "죄송해요" in resp

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -1,0 +1,6 @@
+from subscription_bot.sentiment import analyze_sentiment
+
+
+def test_sentiment():
+    assert analyze_sentiment("I love this service") == "긍정"
+    assert analyze_sentiment("I hate this service") == "부정"


### PR DESCRIPTION
## Summary
- add web crawler, intent classifier, rule-based responses, summarizer and sentiment analyzer
- expose chatbot interface and basic tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ed1987dc08327a272190532ba7bd9