### PR TITLE
Add FastAPI API and tests for chat and health endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pytest
 torch
 transformers
 accelerate
+fastapi
+httpx

--- a/subscription_bot/api.py
+++ b/subscription_bot/api.py
@@ -1,0 +1,36 @@
+"""FastAPI application for SubscriptionBot."""
+
+from __future__ import annotations
+
+from typing import Optional, Dict, Any
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from . import chatbot
+
+
+app = FastAPI()
+
+
+class ChatRequest(BaseModel):
+    """Request body for chat endpoint."""
+
+    question: str
+    context: Optional[Dict[str, Any]] = None
+
+
+@app.post("/chat")
+def chat(request: ChatRequest) -> Dict[str, str]:
+    """Return chatbot answer for the given question."""
+
+    response = chatbot.answer(request.question, request.context)
+    return {"answer": response}
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    """Simple health-check endpoint."""
+
+    return {"status": "ok"}
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+
+from subscription_bot.api import app
+
+
+client = TestClient(app)
+
+
+def test_health():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_chat(monkeypatch):
+    def fake_answer(question, context=None):
+        assert question == "테스트"
+        return "응답"
+
+    monkeypatch.setattr("subscription_bot.chatbot.answer", fake_answer)
+
+    resp = client.post("/chat", json={"question": "테스트"})
+    assert resp.status_code == 200
+    assert resp.json() == {"answer": "응답"}
+


### PR DESCRIPTION
## Summary
- add FastAPI app exposing `/chat` and `/health` endpoints
- add tests for API endpoints and include FastAPI/httpx dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891e358547483278392d0df2501a57e