### PR TITLE
feat: add BERT sentiment analysis

### DIFF
--- a/subscription_bot/sentiment.py
+++ b/subscription_bot/sentiment.py
@@ -1,13 +1,81 @@
-"""Sentiment analysis using VADER."""
+"""Sentiment analysis utilities using both BERT and VADER models."""
+
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Tuple
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+# ---------------------------------------------------------------------------
+# BERT model setup
+# ---------------------------------------------------------------------------
+
+_tokenizer: AutoTokenizer | None = None
+_model: AutoModelForSequenceClassification | None = None
+
+# label mapping from model output index to Korean label
+_LABEL_MAP = {0: "부정", 1: "중립", 2: "긍정"}
+
+
+def load_model(checkpoint: str | None = None) -> Tuple[AutoTokenizer, AutoModelForSequenceClassification]:
+    """Load a BERT sentiment model and tokenizer.
+
+    Parameters
+    ----------
+    checkpoint:
+        Optional local directory or model name to load. If ``None`` or the
+        checkpoint does not exist, a pretrained sentiment analysis model is
+        used instead.
+
+    Returns
+    -------
+    Tuple[AutoTokenizer, AutoModelForSequenceClassification]
+        The loaded tokenizer and model instances.
+    """
+
+    global _tokenizer, _model
+
+    model_name = checkpoint or "cardiffnlp/twitter-roberta-base-sentiment"
+    if checkpoint and not Path(checkpoint).exists():
+        # Fallback to pretrained model when checkpoint is missing
+        model_name = "cardiffnlp/twitter-roberta-base-sentiment"
+
+    _tokenizer = AutoTokenizer.from_pretrained(model_name)
+    _model = AutoModelForSequenceClassification.from_pretrained(model_name)
+
+    return _tokenizer, _model
+
+
+def analyze_sentiment(text: str) -> str:
+    """Return sentiment label (긍정/부정/중립) for ``text`` using BERT."""
+
+    global _tokenizer, _model
+    if _tokenizer is None or _model is None:
+        load_model()
+
+    assert _tokenizer is not None and _model is not None  # for type checkers
+
+    inputs = _tokenizer(text, return_tensors="pt", truncation=True)
+    with torch.no_grad():
+        logits = _model(**inputs).logits
+        label_id = int(torch.argmax(logits, dim=-1))
+
+    return _LABEL_MAP.get(label_id, "중립")
+
+
+# ---------------------------------------------------------------------------
+# VADER sentiment for comparison
+# ---------------------------------------------------------------------------
 
 _analyzer = SentimentIntensityAnalyzer()
 
 
-def analyze_sentiment(text: str) -> str:
-    """Return sentiment label (긍정/부정/중립) for ``text``."""
+def analyze_sentiment_vader(text: str) -> str:
+    """Return sentiment label (긍정/부정/중립) for ``text`` using VADER."""
+
     scores = _analyzer.polarity_scores(text)
     compound = scores["compound"]
     if compound >= 0.05:
@@ -15,3 +83,7 @@ def analyze_sentiment(text: str) -> str:
     if compound <= -0.05:
         return "부정"
     return "중립"
+
+
+__all__ = ["load_model", "analyze_sentiment", "analyze_sentiment_vader"]
+

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -1,6 +1,6 @@
-from subscription_bot.sentiment import analyze_sentiment
+from subscription_bot.sentiment import analyze_sentiment_vader
 
 
-def test_sentiment():
-    assert analyze_sentiment("I love this service") == "긍정"
-    assert analyze_sentiment("I hate this service") == "부정"
+def test_sentiment_vader():
+    assert analyze_sentiment_vader("I love this service") == "긍정"
+    assert analyze_sentiment_vader("I hate this service") == "부정"

--- a/tests/test_sentiment_bert.py
+++ b/tests/test_sentiment_bert.py
@@ -1,0 +1,31 @@
+"""Tests for BERT based sentiment analysis with mocked model."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import torch
+
+import subscription_bot.sentiment as sentiment
+
+
+def _setup_mock(logits: list[float]) -> None:
+    """Configure mocked tokenizer and model returning ``logits``."""
+
+    sentiment._tokenizer = Mock(return_value={"input_ids": torch.tensor([[1]])})
+
+    output = Mock()
+    output.logits = torch.tensor([logits])
+    sentiment._model = Mock(return_value=output)
+
+
+def test_label_mapping_positive_negative_neutral():
+    _setup_mock([0.1, 0.2, 0.7])
+    assert sentiment.analyze_sentiment("foo") == "긍정"
+
+    _setup_mock([0.7, 0.2, 0.1])
+    assert sentiment.analyze_sentiment("bar") == "부정"
+
+    _setup_mock([0.2, 0.6, 0.2])
+    assert sentiment.analyze_sentiment("baz") == "중립"
+


### PR DESCRIPTION
## Summary
- switch sentiment analysis to BERT with fallback model loader
- expose original VADER sentiment as compare function
- test BERT label mapping via mocks

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e356f6c4832796754deb90866538