### PR TITLE
Add LLM-based fallback for unknown intents

### DIFF
--- a/subscription_bot/response.py
+++ b/subscription_bot/response.py
@@ -1,7 +1,10 @@
 """Rule-based response generator with simple fallback."""
 from __future__ import annotations
 
+import re
 from typing import Callable, Dict, Optional
+
+from transformers import pipeline
 
 RULES: Dict[str, Callable[[dict], str]] = {
     "조회": lambda ctx: "현재 구독 중인 상품은 {}입니다.".format(
@@ -16,12 +19,45 @@ RULES: Dict[str, Callable[[dict], str]] = {
 }
 
 
+def _filter_pii(text: str) -> str:
+    """Basic PII filtering for digits and emails."""
+    if not text:
+        return ""
+    text = re.sub(r"[\w.%-]+@[\w.-]+\.[A-Za-z]{2,}", "<EMAIL>", text)
+    text = re.sub(r"\d+", "<NUM>", text)
+    return text
+
+
+def generate_llm_response(
+    intent: str, question: str, context: Optional[dict] = None
+) -> str:
+    """Generate response using an LLM with simple sanitisation.
+
+    This function builds a prompt from the user's ``question`` and optional
+    ``context`` after applying a minimal PII filter. It then queries a small
+    language model via :func:`transformers.pipeline`. Any exception results in a
+    safe fallback message.
+    """
+
+    context = context or {}
+    sanitized_question = _filter_pii(question)
+    sanitized_context = _filter_pii(str(context))
+    prompt = f"사용자 질문: {sanitized_question}\n컨텍스트: {sanitized_context}\n답변:"
+    try:
+        generator = pipeline("text-generation", model="distilgpt2")
+        result = generator(prompt, max_length=100, num_return_sequences=1)
+        return result[0]["generated_text"].strip()
+    except Exception:
+        return "죄송해요. 아직 잘 모르겠어요."
+
+
 def generate_response(intent: str, question: str, context: Optional[dict] = None) -> str:
     """Generate response based on ``intent`` and optional ``context``.
 
-    If ``intent`` is not in predefined rules, a fallback message is returned.
+    If ``intent`` is not in predefined rules, an LLM-based response is used as
+    fallback.
     """
     context = context or {}
     if intent in RULES:
         return RULES[intent](context)
-    return "죄송해요. 아직 잘 모르겠어요."
+    return generate_llm_response(intent, question, context)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -7,6 +7,10 @@ def test_rule_response():
     assert "넷플릭스" in resp
 
 
-def test_fallback():
+def test_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "subscription_bot.response.generate_llm_response",
+        lambda intent, question, context: "죄송해요",
+    )
     resp = generate_response("기타", "모르는 질문", {})
     assert "죄송해요" in resp

--- a/tests/test_response_llm.py
+++ b/tests/test_response_llm.py
@@ -1,0 +1,24 @@
+import pytest
+
+from subscription_bot.response import generate_response
+
+
+def test_llm_fallback(monkeypatch):
+    """Unknown intents should trigger the LLM based fallback."""
+    captured = {}
+
+    def fake_pipeline(task, model):
+        def _generate(prompt, max_length=100, num_return_sequences=1):
+            captured["prompt"] = prompt
+            return [{"generated_text": "llm output"}]
+        return _generate
+
+    monkeypatch.setattr("subscription_bot.response.pipeline", fake_pipeline)
+
+    result = generate_response(
+        "알수없음", "전화번호는 01012345678", {"email": "user@example.com"}
+    )
+
+    assert result == "llm output"
+    assert "<NUM>" in captured["prompt"]
+    assert "<EMAIL>" in captured["prompt"]


### PR DESCRIPTION
## Summary
- integrate a simple LLM client with PII filtering
- fall back to the LLM when intent rules are missing
- test LLM fallback and sanitisation behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891e34cc8f883278b4cc1afa70eb183