### PR TITLE
Add pluggable subscription data backend and tests

### DIFF
--- a/subscription_bot/data/__init__.py
+++ b/subscription_bot/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data storage backends for subscription bot."""

--- a/subscription_bot/data/internal.py
+++ b/subscription_bot/data/internal.py
@@ -1,0 +1,73 @@
+"""Internal data access layer for subscription information.
+
+Provides functions to fetch subscription status, payment history, and
+product metadata using a pluggable storage backend.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Protocol
+
+
+class StorageBackend(Protocol):
+    """Protocol for storage backend implementations."""
+
+    def get_user_subscription_state(self, user_id: str) -> Dict[str, Any]:
+        """Return subscription state for a user."""
+
+    def get_payment_history(self, user_id: str) -> List[Dict[str, Any]]:
+        """Return payment history for a user."""
+
+    def get_product_metadata(self, product_id: str) -> Dict[str, Any]:
+        """Return metadata for a product."""
+
+
+@dataclass
+class InMemoryStorage:
+    """Simple in-memory storage backend.
+
+    Useful for testing or prototyping. Real implementations can swap in a
+    database-backed storage by implementing :class:`StorageBackend`.
+    """
+
+    subscriptions: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    payments: Dict[str, List[Dict[str, Any]]] = field(default_factory=dict)
+    products: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    def get_user_subscription_state(self, user_id: str) -> Dict[str, Any]:
+        return self.subscriptions.get(user_id, {})
+
+    def get_payment_history(self, user_id: str) -> List[Dict[str, Any]]:
+        return self.payments.get(user_id, [])
+
+    def get_product_metadata(self, product_id: str) -> Dict[str, Any]:
+        return self.products.get(product_id, {})
+
+
+_storage_backend: StorageBackend = InMemoryStorage()
+
+
+def set_storage_backend(backend: StorageBackend) -> None:
+    """Configure the global storage backend."""
+
+    global _storage_backend
+    _storage_backend = backend
+
+
+def get_user_subscription_state(user_id: str) -> Dict[str, Any]:
+    """Fetch subscription state for ``user_id`` from the storage backend."""
+
+    return _storage_backend.get_user_subscription_state(user_id)
+
+
+def get_payment_history(user_id: str) -> List[Dict[str, Any]]:
+    """Fetch payment history for ``user_id`` from the storage backend."""
+
+    return _storage_backend.get_payment_history(user_id)
+
+
+def get_product_metadata(product_id: str) -> Dict[str, Any]:
+    """Fetch metadata for ``product_id`` from the storage backend."""
+
+    return _storage_backend.get_product_metadata(product_id)

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,0 +1,37 @@
+import subscription_bot.data.internal as internal
+
+
+def test_get_user_subscription_state():
+    backend = internal.InMemoryStorage(
+        subscriptions={"user123": {"status": "active", "product_id": "prod1"}}
+    )
+    internal.set_storage_backend(backend)
+    result = internal.get_user_subscription_state("user123")
+    assert result == {"status": "active", "product_id": "prod1"}
+    assert isinstance(result, dict)
+
+
+def test_get_payment_history():
+    backend = internal.InMemoryStorage(
+        payments={
+            "user123": [
+                {"amount": 10, "currency": "USD"},
+                {"amount": 5, "currency": "USD"},
+            ]
+        }
+    )
+    internal.set_storage_backend(backend)
+    history = internal.get_payment_history("user123")
+    assert isinstance(history, list)
+    assert history[0]["amount"] == 10
+    assert history[1]["currency"] == "USD"
+
+
+def test_get_product_metadata():
+    backend = internal.InMemoryStorage(
+        products={"prod1": {"name": "Pro Plan", "price": 10.0}}
+    )
+    internal.set_storage_backend(backend)
+    metadata = internal.get_product_metadata("prod1")
+    assert metadata == {"name": "Pro Plan", "price": 10.0}
+    assert isinstance(metadata, dict)


### PR DESCRIPTION
## Summary
- implement internal subscription data access with pluggable storage backend
- provide in-memory storage for subscriptions, payments, and products
- test data access functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893094b0a288327be59fa46160b48cc