### PR TITLE
Add news and price crawlers with tests

### DIFF
--- a/subscription_bot/crawler.py
+++ b/subscription_bot/crawler.py
@@ -6,13 +6,13 @@ extracting title and paragraph text using BeautifulSoup.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict
+from typing import Any, Dict
 
 import requests
 from bs4 import BeautifulSoup
 
 
-def crawl_review(url: str, source: str = "unknown") -> Dict[str, str]:
+def crawl_review(url: str, source: str = "unknown") -> Dict[str, Any]:
     """Fetch ``url`` and extract a review-like JSON structure.
 
     Parameters
@@ -25,8 +25,8 @@ def crawl_review(url: str, source: str = "unknown") -> Dict[str, str]:
     Returns
     -------
     dict
-        A dictionary with ``title``, ``content``, ``source`` and
-        ``published_at`` fields.
+        A dictionary with ``title``, ``content``, ``source``, ``published_at``
+        and ``price`` (always ``None`` for reviews) fields.
     """
     response = requests.get(url, timeout=10)
     response.raise_for_status()
@@ -41,4 +41,94 @@ def crawl_review(url: str, source: str = "unknown") -> Dict[str, str]:
         "content": content,
         "source": source,
         "published_at": datetime.utcnow().strftime("%Y-%m-%d"),
+        "price": None,
+    }
+
+
+def crawl_news(url: str, source: str = "unknown") -> Dict[str, Any]:
+    """Fetch ``url`` and extract news article information.
+
+    Parameters
+    ----------
+    url:
+        URL to crawl.
+    source:
+        Optional label for the source of the news article.
+
+    Returns
+    -------
+    dict
+        A dictionary with ``title``, ``content``, ``source``, ``published_at``
+        and ``price`` (always ``None`` for news) fields.
+    """
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    title = soup.title.string.strip() if soup.title else ""
+    content = " ".join(p.get_text(strip=True) for p in soup.find_all("p"))
+    time_tag = soup.find("time")
+    if time_tag and time_tag.get("datetime"):
+        published_at = time_tag.get("datetime").split("T")[0]
+    else:
+        published_at = datetime.utcnow().strftime("%Y-%m-%d")
+
+    return {
+        "title": title,
+        "content": content,
+        "source": source,
+        "published_at": published_at,
+        "price": None,
+    }
+
+
+def crawl_price(url: str, source: str = "unknown") -> Dict[str, Any]:
+    """Fetch ``url`` and extract price information from a product page.
+
+    Parameters
+    ----------
+    url:
+        URL to crawl.
+    source:
+        Optional label for the source of the product.
+
+    Returns
+    -------
+    dict
+        A dictionary with ``title``, ``content``, ``source``, ``published_at``
+        and ``price`` fields.
+    """
+    import re
+
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    title = soup.title.string.strip() if soup.title else ""
+    content = " ".join(p.get_text(strip=True) for p in soup.find_all("p"))
+
+    time_tag = soup.find("time")
+    if time_tag and time_tag.get("datetime"):
+        published_at = time_tag.get("datetime").split("T")[0]
+    else:
+        published_at = datetime.utcnow().strftime("%Y-%m-%d")
+
+    price = None
+    price_elem = soup.find(attrs={"class": re.compile("price", re.I)}) or soup.find(
+        attrs={"id": re.compile("price", re.I)}
+    )
+    if price_elem:
+        price_text = price_elem.get_text(strip=True)
+        match = re.search(r"[0-9]+(?:\.[0-9]+)?", price_text.replace(",", ""))
+        if match:
+            price = float(match.group())
+
+    return {
+        "title": title,
+        "content": content,
+        "source": source,
+        "published_at": published_at,
+        "price": price,
     }

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,89 @@
+"""Tests for the crawler module."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from subscription_bot import crawler
+
+
+class DummyResponse(SimpleNamespace):
+    """Simple mock object for ``requests`` responses."""
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        return None
+
+
+def test_crawl_review(monkeypatch: pytest.MonkeyPatch) -> None:
+    html = """
+    <html><head><title>Review Title</title></head>
+    <body><p>Review text.</p></body></html>
+    """
+
+    dummy_resp = DummyResponse(text=html)
+    monkeypatch.setattr(crawler.requests, "get", lambda url, timeout=10: dummy_resp)
+
+    class DummyDatetime(datetime):
+        @classmethod
+        def utcnow(cls):  # type: ignore[override]
+            return cls(2023, 1, 1)
+
+    monkeypatch.setattr(crawler, "datetime", DummyDatetime)
+
+    result = crawler.crawl_review("http://example.com")
+    assert result == {
+        "title": "Review Title",
+        "content": "Review text.",
+        "source": "unknown",
+        "published_at": "2023-01-01",
+        "price": None,
+    }
+
+
+def test_crawl_news(monkeypatch: pytest.MonkeyPatch) -> None:
+    html = """
+    <html><head><title>News Title</title></head>
+    <body>
+        <time datetime="2024-02-10T08:00:00Z">Feb 10</time>
+        <p>News content here.</p>
+    </body></html>
+    """
+
+    dummy_resp = DummyResponse(text=html)
+    monkeypatch.setattr(crawler.requests, "get", lambda url, timeout=10: dummy_resp)
+
+    result = crawler.crawl_news("http://example.com/news", source="NewsSite")
+    assert result == {
+        "title": "News Title",
+        "content": "News content here.",
+        "source": "NewsSite",
+        "published_at": "2024-02-10",
+        "price": None,
+    }
+
+
+def test_crawl_price(monkeypatch: pytest.MonkeyPatch) -> None:
+    html = """
+    <html><head><title>Product Title</title></head>
+    <body>
+        <time datetime="2024-03-15T12:00:00Z">Mar 15</time>
+        <p>Product description.</p>
+        <span class="price">$9.99</span>
+    </body></html>
+    """
+
+    dummy_resp = DummyResponse(text=html)
+    monkeypatch.setattr(crawler.requests, "get", lambda url, timeout=10: dummy_resp)
+
+    result = crawler.crawl_price("http://example.com/product", source="Shop")
+    assert result == {
+        "title": "Product Title",
+        "content": "Product description.",
+        "source": "Shop",
+        "published_at": "2024-03-15",
+        "price": 9.99,
+    }
+


### PR DESCRIPTION
## Summary
- extend crawler module with `crawl_news` and `crawl_price` functions
- normalize outputs across crawler functions
- add tests validating crawler behavior

## Testing
- `pytest tests/test_crawler.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68930945b6c08327973fe6f97b512fc1